### PR TITLE
Updated docs/markdown/compile.sh for pandoc version 3.0 compatibility

### DIFF
--- a/docs/markdown/compile.sh
+++ b/docs/markdown/compile.sh
@@ -21,14 +21,14 @@ done
 
 # Generate new Markdown
 cd ..
-pandoc 	--atx-headers \
-		--base-header-level=2 \
+pandoc 	--markdown-headings=atx \
+		--shift-heading-level-by=2 \
 		--number-sections \
 		--default-image-extension=png \
 		--file-scope \
 		--toc \
 		--toc-depth=1 \
-		-t markdown_github \
+		-t gfm \
 		-B markdown/frontmatter.md \
 		-o ../DATASHEET.md \
 		$topfile.tex


### PR DESCRIPTION
--atx-headers, --base-header-level, and -t markdown_github were deprecated, with --atx-headers being incompatible with, pandoc starting with version 3.0.

I changed the compile.sh to use the updated equivalent flags.